### PR TITLE
Update Apache Ivy to 2.5.2 to fix resolution error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ repositories {
 dependencies {
     shade group: 'io.github.spencerpark', name: 'jupyter-jvm-basekernel', version: '2.3.0'
 
-    shade group: 'org.apache.ivy', name: 'ivy', version: '2.5.0-rc1'
+    shade group: 'org.apache.ivy', name: 'ivy', version: '2.5.2'
     //shade group: 'org.apache.maven', name: 'maven-settings-builder', version: '3.6.0'
     shade group: 'org.apache.maven', name: 'maven-model-builder', version: '3.6.0'
 


### PR DESCRIPTION
This updates Apache Ivy to 2.5.2 to fix resolution errors. Before this update, the following error would occur.

```
java.lang.RuntimeException: Exception occurred while running cell magic 'loadFromPOM': Error resolving '/tmp/ijava-ivy-12431898671267929903.xml'. [unresolved dependency: com.google.cloud#google-cloud-core;2.16.0: several problems occurred while resolving dependency: com.google.cloud#google-cloud-core;2.16.0 {compile=[compile(*), master(*)], runtime=[runtime(*)]}:
    several problems occurred while resolving dependency: com.google.cloud#google-cloud-core-parent;2.16.0 {}:
    several problems occurred while resolving dependency: com.google.cloud#google-cloud-shared-dependencies;3.8.0 {}:
    com.google.cloud#google-cloud-core-parent;2.16.0->com.google.api#gapic-generator-java-pom-parent;2.18.0
...
```

cc: @saalfeldlab